### PR TITLE
observe html element rather than body so that the script can be put in <head>

### DIFF
--- a/src/element-internals.js
+++ b/src/element-internals.js
@@ -143,7 +143,7 @@ if (!window.ElementInternals) {
   HTMLElement.prototype.attachShadow = attachShadowObserver;
 
   const documentObserver = new MutationObserver(observerCallback);
-  documentObserver.observe(document.body, observerConfig);
+  documentObserver.observe(document.documentElement, observerConfig);
 
   const formDataOriginal = window.FormData;
 


### PR DESCRIPTION
The script didn't work when I put `<script src="element-internal-polyfill.js"></script>` in `<head>` and I figured that it works when I put it inside `<body>`.

This PR will change where MutationObserver will watch to `<html>` which always exist.