### PR TITLE
observe document element so that the script can be put in <head>

### DIFF
--- a/src/element-internals.js
+++ b/src/element-internals.js
@@ -143,7 +143,7 @@ if (!window.ElementInternals) {
   HTMLElement.prototype.attachShadow = attachShadowObserver;
 
   const documentObserver = new MutationObserver(observerCallback);
-  documentObserver.observe(document.body, observerConfig);
+  documentObserver.observe(document.documentElement, observerConfig);
 
   const formDataOriginal = window.FormData;
 


### PR DESCRIPTION
This PR will change where MutationObserver will watch from `<body>` to `<html>`.

The current script didn't work when `<script src="element-internal-polyfill.js"></script>` is put in `<head>` since the script refers to `document.body` but `body` is not populated yet when a script loaded is loaded in `<head>`. It works if the script tag is put inside <body>, but I think not depending on `document.body` would make this polyfill more useful.

