### PR TITLE
fix(formAssociatedCallback): make sure internals are available when formAssociatedCallback is called

### DIFF
--- a/src/element-internals.ts
+++ b/src/element-internals.ts
@@ -136,7 +136,7 @@ export class ElementInternals implements IElementInternals {
    *
    * If the field is valid and a message is specified, the method will throw a TypeError.
    */
-  setValidity(validityChanges: Partial<globalThis.ValidityState>, validationMessage?: string) {
+  setValidity(validityChanges: Partial<globalThis.ValidityState>, validationMessage?: string, anchor?: HTMLElement) {
     const ref = refMap.get(this);
     if (!validityChanges) {
       throw new TypeError('Failed to execute \'setValidity\' on \'ElementInternals\': 1 argument required, but only 0 present.');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -142,7 +142,9 @@ export const initForm = (ref: ICustomElement, form: HTMLFormElement, internals: 
 
     /** Call formAssociatedCallback if applicable */
     if (ref.constructor['formAssociated'] && ref.formAssociatedCallback) {
-      ref.formAssociatedCallback.apply(ref, [form]);
+      setTimeout(() => {
+        ref.formAssociatedCallback.apply(ref, [form]);
+      }, 0);
     }
   }
 };

--- a/test/ElementInternals.test.js
+++ b/test/ElementInternals.test.js
@@ -8,6 +8,7 @@ import {
 import '../dist/index.js';
 
 let callCount = 0;
+let internalsAvailableInFormAssociatedCallback = false;
 
 class CustomElement extends HTMLElement {
   static get formAssociated() {
@@ -57,6 +58,10 @@ class CustomElement extends HTMLElement {
 
   get value() {
     return this._value;
+  }
+
+  formAssociatedCallback() {
+    internalsAvailableInFormAssociatedCallback = !!this.internals;
   }
 
   formDisabledCallback() {
@@ -277,5 +282,9 @@ describe('The ElementInternals polyfill', () => {
       }, 'This field is required');
       el.internals.checkValidity();
     });
+
+    it('will call formAssociatedCallback after internals have been set', () => {
+      expect(internalsAvailableInFormAssociatedCallback).to.be.true;
+    })
   });
 });


### PR DESCRIPTION
I found that `this.internals` in available when `formAssociatedCallback` is called in the Chrome implementation but not in the polyfill implementation. This fix makes sure to call `formAssociatedCallback` in a later event loop cycle to fix that issue.