### PR TITLE
fix(setFormValue): accept empty strings like Chrome

### DIFF
--- a/src/element-internals.ts
+++ b/src/element-internals.ts
@@ -135,12 +135,12 @@ export class ElementInternals implements IElementInternals {
       return undefined;
     }
     removeHiddenInputs(this);
-    if (value && !(value instanceof FormData)) {
+    if (value != null && !(value instanceof FormData)) {
       if (ref.getAttribute('name')) {
         const hiddenInput = createHiddenInput(ref, this);
         hiddenInput.value = value;
       }
-    } else if (value && value instanceof FormData) {
+    } else if (value != null && value instanceof FormData) {
       value.forEach((formDataValue, formDataKey) => {
         if (typeof formDataValue === 'string') {
           const hiddenInput = createHiddenInput(ref, this);

--- a/test/ElementInternals.test.js
+++ b/test/ElementInternals.test.js
@@ -355,12 +355,17 @@ describe('The ElementInternals polyfill', () => {
       expect(document.activeElement).to.equal(el);
     });
 
-    if('will accept non strings', async () => {
+    it('will accept non strings', async () => {
       internals.setFormValue(['a', 'b']);
       expect(
         new FormData(internals.form).get('foo')
       ).to.equal('a,b');
     });
+
+    it('will accept empty strings', () => {
+      internals.setFormValue('');
+      expect(new FormData(internals.form).get('foo')).to.equal('');
+    })
   });
 
   describe('closed shadow root element', () => {


### PR DESCRIPTION
Found an inconsistency with Chrome. Chrome accepts empty strings in `setFormValue` the polyfill does not.