### PR TITLE
fix: anchor element focus order on form submission reversed compared to Chrome

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,6 +102,7 @@ export const formSubmitCallback = (event: Event) => {
     const nodes = Array.from(elements);
     /** Check the internals.checkValidity() of all nodes */
     const validityList = nodes
+      .reverse()
       .map(node => {
         const internals = internalsMap.get(node);
         return internals.reportValidity();

--- a/test/ElementInternals.test.js
+++ b/test/ElementInternals.test.js
@@ -345,13 +345,24 @@ describe('The ElementInternals polyfill', () => {
 
     it('saves a reference to all shadow roots', () => {
       expect(internals.shadowRoot).to.equal(el.shadowRoot);
-    });;
+    });
 
     it('will focus the element if validated with anchor', async () => {
       internals.setValidity({
         customError: true
       }, 'Error message', el.input);
       internals.reportValidity();
+      expect(document.activeElement).to.equal(el);
+    });
+
+    it('will focus anchor elements in document order on form submission failure', () => {
+      internals.setValidity({
+        customError: true
+      }, 'Error message', el.input);
+      noname.internals.setValidity({
+        customError: true
+      }, 'Error message', noname.input);
+      button.click();
       expect(document.activeElement).to.equal(el);
     });
 


### PR DESCRIPTION
I noticed that the focus order was in reverse compared to Chrome when submitting forms with invalid inputs. This PR corrects that issue.