### PR TITLE
fix(setValidity): Added support for setting ValidityState from a native input as Chrome

### DIFF
--- a/src/element-internals.ts
+++ b/src/element-internals.ts
@@ -166,10 +166,14 @@ export class ElementInternals implements IElementInternals {
     }
     validationAnchorMap.set(this, anchor);
     const validity = validityMap.get(this);
-    if (Object.keys(validityChanges).length === 0) {
+    const validityChangesObj = {};
+    for (const key in validityChanges) {
+      validityChangesObj[key] = validityChanges[key];
+    }
+    if (Object.keys(validityChangesObj).length === 0) {
       setValid(validity);
     }
-    const check = { ...validity, ...validityChanges };
+    const check = { ...validity, ...validityChangesObj };
     delete check.valid;
     const { valid } = reconcileValidty(validity, check);
 

--- a/test/ElementInternals.test.js
+++ b/test/ElementInternals.test.js
@@ -232,6 +232,13 @@ describe('The ElementInternals polyfill', () => {
       }).to.throw();
     });
 
+    it ('will accept ValidityState from a native form input', () => {
+      el.input.required = true;
+      el.input.reportValidity();
+      internals.setValidity(el.input.validity, el.input.validationMessage, el.input);
+      expect(internals.validity.valueMissing).to.be.true;
+    });
+
     it('will return true for willValidate if the field can participate in the form', () => {
       expect(internals.willValidate).to.be.true;
     });


### PR DESCRIPTION
Another Chrome inconsistency. Chrome allows you to call `setValidity` with a `ValidityState` from a native input, this fails in the polyfill.

I found that `Object.keys()` always returns an empty array when passed a `ValidityState` object and spread syntax (...) does not work either. Iterating with `for...in` works though, so I added a step to ensure the input is an object to make sure `Object.keys()` and `...` works as expected.