### PR TITLE
fix: add hidden input for lit-element after render completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.13](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.12...v0.1.13) (2021-03-08)
+
 ### [0.1.12](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.11...v0.1.12) (2021-03-08)
 
 ### [0.1.11](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.10...v0.1.11) (2021-03-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.12](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.11...v0.1.12) (2021-03-08)
+
 ### [0.1.11](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.10...v0.1.11) (2021-03-08)
 
 ### [0.1.10](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.9...v0.1.10) (2021-03-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.11](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.10...v0.1.11) (2021-03-08)
+
 ### [0.1.10](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.9...v0.1.10) (2021-03-08)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.14](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.13...v0.1.14) (2021-03-08)
+
 ### [0.1.13](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.12...v0.1.13) (2021-03-08)
 
 ### [0.1.12](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.11...v0.1.12) (2021-03-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.10](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.9...v0.1.10) (2021-03-08)
+
+
+### Bug Fixes
+
+* add hidden input for lit-element after render completes ([0b93a0a](https://github.com/calebdwilliams/element-internals-polyfill/commit/0b93a0a94158ca83caa82a1b9bd1a3381ca7b322))
+
 ### [0.1.9](https://github.com/calebdwilliams/element-internals-polyfill/compare/v0.1.8...v0.1.9) (2021-02-23)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "element-internals-polyfill",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "element-internals-polyfill",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "element-internals-polyfill",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "element-internals-polyfill",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "element-internals-polyfill",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "element-internals-polyfill",
-  "version": "0.1.9",
+  "name": "@simplex/element-internals-polyfill",
+  "version": "0.1.10",
   "description": "A polyfill for the element internals specification",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplex/element-internals-polyfill",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "A polyfill for the element internals specification",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplex/element-internals-polyfill",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "A polyfill for the element internals specification",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -18,6 +18,9 @@
     "prerelease": "npm run build",
     "release": "standard-version",
     "postrelease": "git push --follow-tags origin master; npm publish"
+  },
+  "publishConfig": {
+    "registry": "https://pkgs.dev.azure.com/daimler-mic/_packaging/mercedes-developer-experience/npm/registry/"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplex/element-internals-polyfill",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "A polyfill for the element internals specification",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplex/element-internals-polyfill",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "A polyfill for the element internals specification",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/element-internals.ts
+++ b/src/element-internals.ts
@@ -142,7 +142,7 @@ export class ElementInternals implements IElementInternals {
   }
 
   /** Sets the element's value within the form */
-  setFormValue(value: string | FormData): void {
+  setFormValue(value: string | FormData | null): void {
     const ref = refMap.get(this);
     throwIfNotFormAssociated(ref, `Failed to execute 'setFormValue' on 'ElementInternals': The target element is not a form-associated custom element.`);
     removeHiddenInputs(this);

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,4 +60,8 @@ export interface ICustomElement extends HTMLElement {
   disabled?: boolean;
 }
 
+export interface ILitElement extends ICustomElement {
+  updateComplete: Promise<void>;
+}
+
 export type LabelsList = NodeListOf<HTMLLabelElement>|[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,17 +40,25 @@ export interface IAom {
 export interface IElementInternals extends IAom {
   checkValidity: () => boolean;
   form: HTMLFormElement;
-  labels: NodeListOf<HTMLLabelElement>|[];
+  labels: NodeListOf<HTMLLabelElement> | [];
   reportValidity: () => boolean;
-  setFormValue: (value: string | FormData) => void;
-  setValidity: (validityChanges: Partial<globalThis.ValidityState>, validationMessage?: string, anchor?: HTMLElement) => void;
+  setFormValue: (value: string | FormData | null) => void;
+  setValidity: (
+    validityChanges: Partial<globalThis.ValidityState>,
+    validationMessage?: string,
+    anchor?: HTMLElement
+  ) => void;
   validationMessage: string;
   validity: globalThis.ValidityState;
   willValidate: boolean;
 }
 
 export interface ICustomElement extends HTMLElement {
-  attributeChangedCallback?: (name: string, oldValue: any, newValue: any) => void;
+  attributeChangedCallback?: (
+    name: string,
+    oldValue: any,
+    newValue: any
+  ) => void;
   connectedCallback?: () => void;
   disconnectedCallback?: () => void;
   attachedCallback?: () => void;
@@ -64,4 +72,4 @@ export interface ILitElement extends ICustomElement {
   updateComplete: Promise<void>;
 }
 
-export type LabelsList = NodeListOf<HTMLLabelElement>|[];
+export type LabelsList = NodeListOf<HTMLLabelElement> | [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { hiddenInputMap, formsMap, formElementsMap, internalsMap } from './maps.js';
-import { ICustomElement, IElementInternals, LabelsList } from './types.js';
+import { ICustomElement, IElementInternals, ILitElement, LabelsList } from './types.js';
 
 const observerConfig: MutationObserverInit = { attributes: true };
 
@@ -47,11 +47,15 @@ export const removeHiddenInputs = (internals: IElementInternals): void => {
  * @param {IElementInternals} internals - The element internals instance for the ref
  * @return {HTMLInputElement} The hidden input
  */
-export const createHiddenInput = (ref: ICustomElement, internals: IElementInternals): HTMLInputElement | null => {
+export const createHiddenInput = (ref: ICustomElement | ILitElement, internals: IElementInternals): HTMLInputElement | null => {
   const input = document.createElement('input');
   input.type = 'hidden';
   input.name = ref.getAttribute('name');
-  ref.after(input);
+  if ((<ILitElement>ref).updateComplete) {
+    (<ILitElement>ref).updateComplete.then(() => ref.after(input));
+  } else {
+    ref.after(input);
+  }
   hiddenInputMap.get(internals).push(input);
   return input;
 }


### PR DESCRIPTION
Lit-element rendering has issue with setting element before it does it's first update.  You can see this best when creating a custom element that uses a select element underneath.  Options for the select are rendered in plain text a few elements because the custom element.

This is framework specific so I don't know if this is something you would like in this polyfill.  