### PR TITLE
fix: add missing null to shadowRoot

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export interface IElementInternals extends IAom {
     validationMessage?: string,
     anchor?: HTMLElement
   ) => void;
-  shadowRoot: ShadowRoot;
+  shadowRoot: ShadowRoot | null;
   validationMessage: string;
   validity: globalThis.ValidityState;
   willValidate: boolean;


### PR DESCRIPTION
I found a small issue in the typedefs :

```
../../node_modules/element-internals-polyfill/dist/element-internals.d.ts:61:9 - error TS2416: Property 'shadowRoot' in type 'ElementInternals' is not assignable to the same property in base type 'IElementInternals'.
  Type 'ShadowRoot | null' is not assignable to type 'ShadowRoot'.
    Type 'null' is not assignable to type 'ShadowRoot'.
```

This PR fix this