### PR TITLE
form.elements getter and similar returned HTMLFormControlsColle…

### DIFF
--- a/src/element-internals.ts
+++ b/src/element-internals.ts
@@ -368,10 +368,10 @@ function decorateNamedCollection(node, name){
 function decorateNamedItemsCollection(node){
   const { name, id } = node;
   if(name){
-    decorateNamed.call(this, node, name);
+    decorateNamedCollection.call(this, node, name);
   }
   if(id){
-    decorateNamed.call(this, node, id);
+    decorateNamedCollection.call(this, node, id);
   }
 }
 


### PR DESCRIPTION
this attempts to extend `form.elements` with any participating form elements as-expected for issue #43 

it's untested