### PR TITLE
Form discovery inconsistency

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -242,8 +242,6 @@ export const findParentForm = (elem) => {
   let parent = elem.parentNode;
   if (parent && parent.tagName !== 'FORM') {
     parent = findParentForm(parent);
-  } else if (!parent && elem.toString() === '[object ShadowRoot]') {
-    parent = findParentForm(elem.host);
   }
   return parent;
 };

--- a/test/ElementInternals.test.js
+++ b/test/ElementInternals.test.js
@@ -531,4 +531,24 @@ describe('The ElementInternals polyfill', () => {
       expect(submitCount).to.equal(1);
     });
   });
+
+  describe('forms outside closed custom elements', () => {
+    it('will not find forms outside of closed custom element', async () => {
+      class ClosedElementWithCustomFormElement extends HTMLElement {
+        constructor() {
+          super();
+          this.renderRoot = this.attachShadow({ mode: 'closed' });
+          this.renderRoot.innerHTML = `<test-el name="foo" id="foo"></test-el>`;
+        }
+      }
+      customElements.define('closed-element-with-custom-form-element', ClosedElementWithCustomFormElement);
+
+      const form = await fixture(html`<form>
+        <closed-element-with-custom-form-element></closed-element-with-custom-form-element>
+      </form>`);
+      const shadowElement = form.querySelector('closed-element-with-custom-form-element');
+      const testEl = shadowElement.renderRoot.querySelector("test-el")
+      expect(testEl.internals.form).to.be.null;
+    });
+  });
 });


### PR DESCRIPTION
I found that Chrome does not search past closed shadow roots for the form element. This made the polyfill inconsistent with the Chrome implementation. Running the test without the fix should confirm it. I wasn't able to run the tests on Safari so if someone else can do that to confirm it works it would be super.