### PR TITLE
Fix: fix nodes added in a tree in Safari

### DIFF
--- a/src/mutation-observers.ts
+++ b/src/mutation-observers.ts
@@ -40,7 +40,7 @@ export function observerCallback(mutationList: MutationRecord[]) {
         const walker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT, {
           acceptNode(node: ICustomElement): number {
             return internalsMap.has(node) && !formElements?.has(node) ?
-              NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+              NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
           }
         });
 


### PR DESCRIPTION
This PR is an improvement for the fix for issue #73 

FILTER_REJECT rejects nodes that might have children
of type form-associated custom elements. Instead, use FILTER_SKIP.
This option traverses the children in such cases.