### PR TITLE
Fix issue #40.

### DIFF
--- a/src/maps.ts
+++ b/src/maps.ts
@@ -43,6 +43,3 @@ export const validationAnchorMap = new WeakMap<IElementInternals, HTMLElement>()
 
 /** Map DocumentFragments to their MutationObservers so we can disconnect once elements are removed */
 export const documentFragmentMap = new WeakMap<DocumentFragment, MutationObserver>();
-
-/** Save references to the form onsubmit if present */
-export const onSubmitMap = new WeakMap<HTMLFormElement, Function>();


### PR DESCRIPTION
Listen for submit events on the closest submit button and if the form is invalid prevent the default handling.
For more information see this [explanation](https://github.com/calebdwilliams/element-internals-polyfill/issues/40#issuecomment-1244024843).