### PR TITLE
fix(utils): flip order of nativeControlValidity filter predicate check

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -88,7 +88,7 @@ export const initLabels = (ref: ICustomElement, labels: LabelsList): void => {
  */
 export const setFormValidity = (form: HTMLFormElement) => {
   const nativeControlValidity = Array.from(form.elements)
-    .filter((element: Element & { validity: ValidityState }) => element.validity && !element.tagName.includes('-'))
+    .filter((element: Element & { validity: ValidityState }) => !element.tagName.includes('-') && element.validity)
     .map(
       (element: Element & { validity: ValidityState }) => element.validity.valid
     );


### PR DESCRIPTION
reverse the order of the check so that if the control is NOT a native control it doesnt have to have a validity object established when this setFormValidity function runs. It could run in the constructor and not have validity or attributes yet because of the microtask etc.