### PR TITLE
fix: rollback use of ?? and ?. operators to maintain compatibility with legacy build systems, such as those used in storybook

### DIFF
--- a/src/HTMLFormControlsCollection.ts
+++ b/src/HTMLFormControlsCollection.ts
@@ -27,10 +27,10 @@ export class HTMLFormControlsCollection implements globalThis.HTMLFormControlsCo
   }
 
   item(i): Element {
-    return this[i] ?? null;
+    return this[i] == null ? null : this[i];
   }
 
   namedItem(name): Element {
-    return this[name] ?? null;
+    return this[name] == null ? null : this[name];
   }
 }

--- a/src/element-internals.ts
+++ b/src/element-internals.ts
@@ -326,7 +326,9 @@ if (!isElementInternalsSupported()) {
           }
         }
 
-        connectedCallback?.apply(this);
+        if (connectedCallback != null) {
+          connectedCallback.apply(this);
+        }
       };
     }
 


### PR DESCRIPTION
The default build system shipped with @storybook/web-components does not include support for the `??` or `.?` operators.

It can be argued that the build system should be updated to support these, but seeing as the rest of this library is fully compatible, this small change would be a quality of life improvement for me and my team's use case.