### PR TITLE
Running implementation refactors for jest/jsdom environment

### DIFF
--- a/src/element-internals.ts
+++ b/src/element-internals.ts
@@ -90,19 +90,6 @@ export class ElementInternals implements IElementInternals {
     initRef(ref, this);
     Object.seal(this);
 
-    // upgrade internals instantly only if the element is connected to the DOM
-    // otherwise, wait until the callstack is cleared as the element is most likely
-    // still being constructed and wont have a parent form element yet
-
-    // TODO: should deferUpgrade() be used here?
-    if(ref.isConnected) {
-      upgradeInternals(ref);
-    } else {
-      setTimeout(() => {
-        upgradeInternals(ref);
-      })
-    }
-
     /**
      * If appended from a DocumentFragment, wait until it is connected
      * before attempting to upgrade the internals instance
@@ -342,6 +329,8 @@ if (!isElementInternalsSupported()) {
           if (connectedCallback != null) {
             connectedCallback.apply(this);
           }
+          // always upgradeInternals in connectedCallback instead of constructor
+          upgradeInternals(this);
         };
       }
 

--- a/src/element-internals.ts
+++ b/src/element-internals.ts
@@ -90,7 +90,18 @@ export class ElementInternals implements IElementInternals {
     initRef(ref, this);
     Object.seal(this);
 
-    upgradeInternals(ref);
+    // upgrade internals instantly only if the element is connected to the DOM
+    // otherwise, wait until the callstack is cleared as the element is most likely
+    // still being constructed and wont have a parent form element yet
+
+    // TODO: should deferUpgrade() be used here?
+    if(ref.isConnected) {
+      upgradeInternals(ref);
+    } else {
+      setTimeout(() => {
+        upgradeInternals(ref);
+      })
+    }
 
     /**
      * If appended from a DocumentFragment, wait until it is connected

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -130,7 +130,7 @@ export const formInputCallback = (event: Event) => {
  * @return {void}
  */
 export const wireSubmitLogic = (form: HTMLFormElement) => {
-  const SUBMIT_BUTTON_SELECTOR = ':is(:is(button, input)[type=submit], button:not([type])):not([disabled])';
+  const SUBMIT_BUTTON_SELECTOR = ':is(button[type=submit], input[type=submit], button:not([type])):not([disabled])';
   let submitButtonSelector = `${SUBMIT_BUTTON_SELECTOR}:not([form])`;
 
   if (form.id) {
@@ -138,7 +138,7 @@ export const wireSubmitLogic = (form: HTMLFormElement) => {
   }
 
   form.addEventListener('click', event => {
-    const target = event.target as Element;
+    const target = event.currentTarget as Element;
     if (target.closest(submitButtonSelector)) {
       // validate
       const elements = formElementsMap.get(form);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,7 +138,7 @@ export const wireSubmitLogic = (form: HTMLFormElement) => {
   }
 
   form.addEventListener('click', event => {
-    const target = event.currentTarget as Element;
+    const target = event.target as Element;
     if (target.closest(submitButtonSelector)) {
       // validate
       const elements = formElementsMap.get(form);


### PR DESCRIPTION
would love your input on the `upgradeInternals` change and how/whether or not to use `deferUpgrade()` there instead.

The issue is that in react/jest/jsdom, each FACE needs a polyfilled internals because jsom doesn't support `attachInternals()`. Since react renders in a depth-first approach, each FACE is constructed basically standalone. Therefore, the `findParentForm()` feature of the `upgradeInternals()` process will return null and the form's initial validity won't be correct because not all the child FACE's will be registered in the internal elements map used for validity.