### PR TITLE
fix: remove :is in submit selector to prevent error in non-supporting browsers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -130,12 +130,10 @@ export const formInputCallback = (event: Event) => {
  * @return {void}
  */
 export const wireSubmitLogic = (form: HTMLFormElement) => {
-  const SUBMIT_BUTTON_SELECTOR = ':is(button[type=submit], input[type=submit], button:not([type])):not([disabled])';
-  let submitButtonSelector = `${SUBMIT_BUTTON_SELECTOR}:not([form])`;
-
-  if (form.id) {
-    submitButtonSelector += `,${SUBMIT_BUTTON_SELECTOR}[form='${form.id}']`;
-  }
+  const submitButtonSelector = ['button[type=submit]', 'input[type=submit]', 'button:not([type])']
+    .map(sel => `${sel}:not([disabled])`)
+    .map(sel => `${sel}:not([form])${form.id ? `,${sel}[form='${form.id}']` : ''}`)
+    .join(',');
 
   form.addEventListener('click', event => {
     const target = event.target as Element;


### PR DESCRIPTION
Hi there,

Great work in the polyfill. Thank you :)

The polyfill throws an error in Safari 13 when clicking in a form, due to `:is` selector not being supported.

This PR selects the same elements but without using `:is`.
Working example: [https://jsitor.com/dAkiiSwGBO](https://jsitor.com/dAkiiSwGBO)

Related to #82 and #40 

Thanks!

