### PR TITLE
fix: only inits form association if element is form associated

### DIFF
--- a/src/mutation-observers.ts
+++ b/src/mutation-observers.ts
@@ -105,8 +105,9 @@ export function observerCallback(mutationList: MutationRecord[]) {
         const formElements = formElementsMap.get(node as unknown as HTMLFormElement);
         const walker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT, {
           acceptNode(node: ICustomElement): number {
-            return internalsMap.has(node) && !(formElements && formElements.has(node)) ?
-              NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+            return (
+              internalsMap.has(node) && node.constructor['formAssociated'] && !(formElements && formElements.has(node))
+            ) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
           }
         });
 

--- a/test/ElementInternals.test.js
+++ b/test/ElementInternals.test.js
@@ -182,6 +182,7 @@ describe('The ElementInternals polyfill', () => {
       constructor() {
         super();
         this.internals = this.attachInternals();
+        this.internals.role = 'generic';
       }
     }
 
@@ -200,6 +201,16 @@ describe('The ElementInternals polyfill', () => {
     it('will throw from setFormValue', async () => {
       expect(() => element.internals.setFormValue('foo')).to.throw();
     });
+
+    describe('inside a form', () => {
+      let form;
+
+      afterEach(async () => await fixtureCleanup(form));
+
+      it('will not throw', async () => {
+        form = await fixture(html`<form><not-associated></not-associated></form>`);
+      })
+    })
   });
 
   describe('inside a custom element with a form', () => {


### PR DESCRIPTION
I found this bug while developing some components, and relying in element internals for setting aria attributes.

If you place a non form associated element inside of a form, the polyfill treats it as a form associated element and that fails. 