### PR TITLE
Expose functions to force the polyfill and make not exception with WC polyfill

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,17 @@
-import { ElementInternals } from './element-internals.js';
+import {
+  ElementInternals,
+  forceCustomStateSetPolyfill,
+  forceElementInternalsPolyfill,
+  isElementInternalsSupported,
+} from './element-internals.js';
 import { CustomStateSet } from './CustomStateSet.js';
 import './element-internals.js';
 import { IElementInternals } from './types.js';
 export * from './types.js';
+export {
+  forceCustomStateSetPolyfill,
+  forceElementInternalsPolyfill,
+} from './element-internals.js';
 
 declare global {
   interface Window {
@@ -16,5 +25,22 @@ declare global {
      * on a built-in element will throw an error.
      */
     attachInternals(): ElementInternals&IElementInternals;
+  }
+}
+
+// Deteermine whether the webcomponents polyfill has been applied.
+const isCePolyfill = !!(
+  customElements as unknown as {
+    polyfillWrapFlushCallback: () => void;
+  }
+).polyfillWrapFlushCallback;
+
+// custom elements polyfill is on. Do not auto-apply. User should determine
+// whether to force or not.
+if (!isCePolyfill) {
+  if (!isElementInternalsSupported()) {
+    forceElementInternalsPolyfill(false);
+  } else if (typeof window !== "undefined" && !window.CustomStateSet) {
+    forceCustomStateSetPolyfill(HTMLElement.prototype.attachInternals);
   }
 }

--- a/src/mutation-observers.ts
+++ b/src/mutation-observers.ts
@@ -164,18 +164,18 @@ export function fragmentObserverCallback(mutationList: MutationRecord[]): void {
  * @param fragment {DocumentFragment}
  */
  export const deferUpgrade = (fragment: DocumentFragment) => {
-   const observer = new MutationObserver(fragmentObserverCallback);
-   // is this using shady DOM and is not actually a DocumentFragment?
-   if (
-     window?.ShadyDOM?.inUse &&
-     (fragment as unknown as { mode: string }).mode &&
-     (fragment as unknown as { host: HTMLElement | null }).host
-   ) {
-     // using shady DOM polyfill. Best to just observe the host.
-     fragment = (fragment as ShadowRoot).host as unknown as DocumentFragment;
-   }
-   observer.observe?.(fragment, { childList: true });
-   documentFragmentMap.set(fragment, observer);
+  const observer = new MutationObserver(fragmentObserverCallback);
+  // is this using shady DOM and is not actually a DocumentFragment?
+  if (
+    window?.ShadyDOM?.inUse &&
+    (fragment as unknown as { mode: string }).mode &&
+    (fragment as unknown as { host: HTMLElement | null }).host
+  ) {
+    // using shady DOM polyfill. Best to just observe the host.
+    fragment = (fragment as ShadowRoot).host as unknown as DocumentFragment;
+  }
+  observer.observe?.(fragment, { childList: true });
+  documentFragmentMap.set(fragment, observer);
  };
 
 export const observer = mutationObserverExists() ? new MutationObserver(observerCallback) : {} as MutationObserver;

--- a/src/mutation-observers.ts
+++ b/src/mutation-observers.ts
@@ -164,10 +164,19 @@ export function fragmentObserverCallback(mutationList: MutationRecord[]): void {
  * @param fragment {DocumentFragment}
  */
  export const deferUpgrade = (fragment: DocumentFragment) => {
-  const observer = new MutationObserver(fragmentObserverCallback)
-  observer.observe?.(fragment, { childList: true });
-  documentFragmentMap.set(fragment, observer);
-};
+   const observer = new MutationObserver(fragmentObserverCallback);
+   // is this using shady DOM and is not actually a DocumentFragment?
+   if (
+     window?.ShadyDOM?.inUse &&
+     (fragment as unknown as { mode: string }).mode &&
+     (fragment as unknown as { host: HTMLElement | null }).host
+   ) {
+     // using shady DOM polyfill. Best to just observe the host.
+     fragment = (fragment as ShadowRoot).host as unknown as DocumentFragment;
+   }
+   observer.observe?.(fragment, { childList: true });
+   documentFragmentMap.set(fragment, observer);
+ };
 
 export const observer = mutationObserverExists() ? new MutationObserver(observerCallback) : {} as MutationObserver;
 export const observerConfig: MutationObserverInit = {


### PR DESCRIPTION
We expose the `forceCustomStateSetPolyfill()` and `forceElementInternalsPolyfill()` functions as well as make the polyfill not **exception** when the Custom Elements and or the Shady DOM Polyfill is also applied. **NOTE:** with these polyfills, the EI polyfill will not work as intended, but it enables custom elements using ElementInternals from exceptioning in these cases.

The main use case for this is for consuming WCs that use ElementInternals Chrome extensions. Content Scripts in Chrome extensions (until we have scoped custom elements) require you use the CE polyfill. WCs that have ElementInternals will exception because they are being applied to non-custom elements. This polyfill will not help because it does feature detection and chrome has EI. Therefore we need EI polyfill to be forced.