### PR TITLE
Add ariaDescription to interfaces

### DIFF
--- a/src/aom.ts
+++ b/src/aom.ts
@@ -11,6 +11,7 @@ export const aom: IAom = {
   ariaColIndexText: 'aria-colindextext',
   ariaColSpan: 'aria-colspan',
   ariaCurrent: 'aria-current',
+  ariaDescription: 'aria-description',
   ariaDisabled: 'aria-disabled',
   ariaExpanded: 'aria-expanded',
   ariaHasPopup: 'aria-haspopup',

--- a/src/element-internals.ts
+++ b/src/element-internals.ts
@@ -37,6 +37,7 @@ export class ElementInternals implements IElementInternals {
   ariaColIndexText: string;
   ariaColSpan: string;
   ariaCurrent: string;
+  ariaDescription: string;
   ariaDisabled: string;
   ariaExpanded: string;
   ariaHasPopup: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface IAom {
   ariaColIndexText: string;
   ariaColSpan: string;
   ariaCurrent: string;
+  ariaDescription: string;
   ariaDisabled: string;
   ariaExpanded: string;
   ariaHasPopup: string;


### PR DESCRIPTION
Fixes #128 

Supports change to TypeScript's generated DOM `ARIAMixin` interface in TS 5.4.