### PR TITLE
add support for ariaBrailleLabel and ariaBrailleRoleDescription

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ In addition to form controls, `ElementInternals` will also surface several acces
 
 - `ariaAtomic`: 'aria-atomic'
 - `ariaAutoComplete`: 'aria-autocomplete'
+- `ariaBrailleLabel`: 'aria-braillelabel'
+- `ariaBrailleRoleDescription`: 'aria-brailleroledescription'
 - `ariaBusy`: 'aria-busy'
 - `ariaChecked`: 'aria-checked'
 - `ariaColCount`: 'aria-colcount'

--- a/jsdom-tests/polyfill.js
+++ b/jsdom-tests/polyfill.js
@@ -20,6 +20,8 @@
     const aom = {
         ariaAtomic: 'aria-atomic',
         ariaAutoComplete: 'aria-autocomplete',
+        ariaBrailleLabel: 'aria-braillelabel',
+        ariaBrailleRoleDescription: 'aria-brailleroledescription',
         ariaBusy: 'aria-busy',
         ariaChecked: 'aria-checked',
         ariaColCount: 'aria-colcount',

--- a/src/aom.ts
+++ b/src/aom.ts
@@ -4,6 +4,8 @@ import { IAom, IElementInternals } from './types.js';
 export const aom: IAom = {
   ariaAtomic: 'aria-atomic',
   ariaAutoComplete: 'aria-autocomplete',
+  ariaBrailleLabel: 'aria-braillelabel',
+  ariaBrailleRoleDescription: 'aria-brailleroledescription',
   ariaBusy: 'aria-busy',
   ariaChecked: 'aria-checked',
   ariaColCount: 'aria-colcount',

--- a/src/element-internals.ts
+++ b/src/element-internals.ts
@@ -30,6 +30,8 @@ import { patchFormPrototype } from './patch-form-prototype.js';
 export class ElementInternals implements IElementInternals {
   ariaAtomic: string;
   ariaAutoComplete: string;
+  ariaBrailleLabel: string;
+  ariaBrailleRoleDescription: string;
   ariaBusy: string;
   ariaChecked: string;
   ariaColCount: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ import { ElementInternals } from './element-internals.js';
 export interface IAom {
   ariaAtomic: string;
   ariaAutoComplete: string;
+  ariaBrailleLabel: string;
+  ariaBrailleRoleDescription: string;
   ariaBusy: string;
   ariaChecked: string;
   ariaColCount: string;


### PR DESCRIPTION
Was experiencing the same issues as described in https://github.com/calebdwilliams/element-internals-polyfill/issues/133. This is my fix for it. Noticed after the fact that that there was already a fix in https://github.com/calebdwilliams/element-internals-polyfill/pull/134, so feel free to close this in favor of that one if necessary.