### PR TITLE
Fix attributeChangedCallback when calling setValidity

### DIFF
--- a/src/aom.ts
+++ b/src/aom.ts
@@ -1,5 +1,6 @@
 import { upgradeMap } from './maps.js';
 import { IAom, IElementInternals } from './types.js';
+import { setAttribute } from './utils.js';
 
 export const aom: IAom = {
   ariaAtomic: 'aria-atomic',
@@ -59,7 +60,7 @@ export const initAom = (ref: Element, internals: IElementInternals) => {
       set(value) {
         closureValue = value;
         if (ref.isConnected) {
-          ref.setAttribute(attributeName, value);
+          setAttribute(ref, attributeName, value);
         } else {
           upgradeMap.set(ref, internals);
         }

--- a/src/element-internals.ts
+++ b/src/element-internals.ts
@@ -11,6 +11,7 @@ import {
   validityUpgradeMap,
 } from './maps.js';
 import {
+  setAttribute,
   createHiddenInput,
   findParentForm,
   initRef,
@@ -223,7 +224,7 @@ export class ElementInternals implements IElementInternals {
     if (ref.isConnected) {
       ref.toggleAttribute('internals-invalid', !valid);
       ref.toggleAttribute('internals-valid', valid);
-      ref.setAttribute('aria-invalid', `${!valid}`);
+      setAttribute(ref, 'aria-invalid', `${!valid}`);
     } else {
       validityUpgradeMap.set(ref, this);
     }

--- a/src/mutation-observers.ts
+++ b/src/mutation-observers.ts
@@ -1,6 +1,6 @@
 import { internalsMap, shadowHostsMap, upgradeMap, hiddenInputMap, documentFragmentMap, formElementsMap, validityUpgradeMap, refValueMap } from './maps.js';
 import { aom } from './aom.js';
-import { removeHiddenInputs, initForm, initLabels, upgradeInternals, setDisabled, mutationObserverExists } from './utils.js';
+import { setAttribute, removeHiddenInputs, initForm, initLabels, upgradeInternals, setDisabled, mutationObserverExists } from './utils.js';
 import { ICustomElement } from './types.js';
 
 function initNode(node: ICustomElement): void {
@@ -86,7 +86,7 @@ export function observerCallback(mutationList: MutationRecord[]) {
         aomKeys
           .filter(key => internals[key] !== null)
           .forEach(key => {
-            node.setAttribute(aom[key], internals[key]);
+            setAttribute(node, aom[key], internals[key]);
           });
         upgradeMap.delete(node);
       }
@@ -94,9 +94,9 @@ export function observerCallback(mutationList: MutationRecord[]) {
       /** Upgrade the validity state when the element is connected */
       if (validityUpgradeMap.has(node)) {
         const internals = validityUpgradeMap.get(node);
-        node.setAttribute('internals-valid', internals.validity.valid.toString());
-        node.setAttribute('internals-invalid', (!internals.validity.valid).toString());
-        node.setAttribute('aria-invalid', (!internals.validity.valid).toString());
+        setAttribute(node, 'internals-valid', internals.validity.valid.toString());
+        setAttribute(node, 'internals-invalid', (!internals.validity.valid).toString());
+        setAttribute(node, 'aria-invalid', (!internals.validity.valid).toString());
         validityUpgradeMap.delete(node);
       }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,32 @@ import { disabledOrNameObserver, disabledOrNameObserverConfig } from './mutation
 import { ICustomElement, IElementInternals, LabelsList } from './types.js';
 
 /**
+ * Set attribute if its value differs from existing one.
+ * 
+ * In comparison to other attribute modification methods (removeAttribute and
+ * toggleAttribute), setAttribute always triggers attributeChangedCallback
+ * even if the actual value has not changed.
+ * 
+ * This polyfill relies heavily on attributes to pass aria information to 
+ * screen readers. This behaviour differs from native implementation which does
+ * not change attributes.
+ * 
+ * To limit this difference we only set attribute value when it is different
+ * from the current state.
+ * 
+ * @param {ICustomElement | Element} ref - The custom element instance
+ * @param {string} name - The attribute name
+ * @param {string} value - The attribute value
+ * @returns 
+ */
+export const setAttribute = (ref: ICustomElement | Element, name: string, value: string): void => {
+  if (ref.getAttribute(name) === value) {
+    return;
+  }
+  ref.setAttribute(name, value);
+}
+
+/**
  * Toggle's the disabled state (attributes & callback) on the given element
  * @param {ICustomElement} ref - The custom element instance
  * @param {boolean} disabled - The disabled state
@@ -11,7 +37,7 @@ export const setDisabled = (ref: ICustomElement, disabled: boolean): void => {
   ref.toggleAttribute('internals-disabled', disabled);
 
   if (disabled) {
-    ref.setAttribute('aria-disabled', 'true');
+    setAttribute(ref, 'aria-disabled', 'true');
   } else {
     ref.removeAttribute('aria-disabled');
   }
@@ -76,7 +102,7 @@ export const initLabels = (ref: ICustomElement, labels: LabelsList): void => {
       firstLabelId = `${labels[0].htmlFor}_Label`;
       labels[0].id = firstLabelId;
     }
-    ref.setAttribute('aria-labelledby', firstLabelId);
+    setAttribute(ref, 'aria-labelledby', firstLabelId);
   }
 };
 


### PR DESCRIPTION
## Context

Polyfill works differently than native implementation because it is limited by browser capabilities. Specifically polyfill lacks special interaction of `ElementInternals` with a11y tools (like screen readers).

Native `ElementInternals` reports validity status to screen readers without using aria-* attributes (specifically `aria-invalid`).

In comparison to other attribute modification methods (`removeAttribute` and `toggleAttribute`), `setAttribute` always triggers `attributeChangedCallback` even if the actual value has not changed.

## Problem
In my code I call `setValidity` from attribute changed callback. My component's validation relies on attributes, so when they have changed it makes sense to revalidate it.

Simplifying I can illustrate the problem with the following code:
```
class MyComponent extends HTMLElement {
  // ...
  attributeChangedCallback() {
    this.internals.setValidity(this.validate(), 'error message');
  }
  
  private validate() {
    const maxLength = Number(this.getAttribute('max-length'))
    return {tooLong: (this.value.length > maxLength)}
  }
  // ...
}
<my-component max-length="50" value="hello"></my-component>
```

This approach works perfect with a native `ElementInternals` but with polyfill it resolves into infinite loop. Every call to `setValidity` has ``ref.setAttribute('aria-invalid', `${!valid}`)`` inside which triggers another `attributeChangedCallback` and so on.

While it is easy to fix the problem in my code (i can filter which attributes will trigger revalidation) I think it worth it to fix the library as well.

It took me quite some time to find this bug because it only reproducible with the polyfill and the root cause is behaviour difference between Polyfill and native implementation. I absolutely did not expect `ElementInternals` to trigger `attributeChangedCallback`.

While I understand the need to do that, I think with this additional check we can limit the impact of this difference and at least avoid infinite loops.